### PR TITLE
Let plugin fail on error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '17'
           cache: 'gradle'
       - name: Production Build
         run: ./gradlew clean jar

--- a/src/main/java/de/tum/cit/ase/artemis_notification_plugin/NotificationPlugin.java
+++ b/src/main/java/de/tum/cit/ase/artemis_notification_plugin/NotificationPlugin.java
@@ -3,6 +3,7 @@ package de.tum.cit.ase.artemis_notification_plugin;
 import com.google.gson.Gson;
 import de.tum.cit.ase.artemis_notification_plugin.configuration.Context;
 import de.tum.cit.ase.artemis_notification_plugin.configuration.ContextFactory;
+import de.tum.cit.ase.artemis_notification_plugin.exception.PostResultException;
 import de.tum.cit.ase.artemis_notification_plugin.exception.TestParsingException;
 import de.tum.cit.ase.artemis_notification_plugin.model.Commit;
 import de.tum.cit.ase.artemis_notification_plugin.model.TestResults;
@@ -91,6 +92,7 @@ public abstract class NotificationPlugin {
         }
         catch (HttpException | IOException e) {
             LOGGER.error(e.getMessage(), e);
+            throw new PostResultException(e);
         }
     }
 

--- a/src/main/java/de/tum/cit/ase/artemis_notification_plugin/exception/PostResultException.java
+++ b/src/main/java/de/tum/cit/ase/artemis_notification_plugin/exception/PostResultException.java
@@ -1,0 +1,8 @@
+package de.tum.cit.ase.artemis_notification_plugin.exception;
+
+public class PostResultException extends RuntimeException {
+
+    public PostResultException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/test/java/de/tum/cit/ase/artemis_notification_plugin/model/TestsuiteTest.java
+++ b/src/test/java/de/tum/cit/ase/artemis_notification_plugin/model/TestsuiteTest.java
@@ -1,5 +1,8 @@
 package de.tum.cit.ase.artemis_notification_plugin.model;
 
+import de.tum.cit.ase.artemis_notification_plugin.CLIPlugin;
+import de.tum.cit.ase.artemis_notification_plugin.configuration.Context;
+import de.tum.cit.ase.artemis_notification_plugin.exception.PostResultException;
 import org.junit.jupiter.api.Test;
 
 import javax.xml.bind.JAXBContext;
@@ -60,6 +63,12 @@ class TestsuiteTest {
         assertEquals(12, flattened.getTestCases().size());
         assertEquals(2, flattened.getFailures());
         assertEquals(1, flattened.getErrors());
+    }
+
+    @Test
+    void testPostResultFailure() {
+        CLIPlugin cliPlugin = new CLIPlugin();
+        assertThrows(PostResultException.class, () -> cliPlugin.postResult(new TestResults(), new Context(null, null, null, null, null, null, null, null, null, null, null, "http://invalid", "secret")));
     }
 
     private Testsuite loadTestSuite(final Path reportXml) throws JAXBException {


### PR DESCRIPTION
If there is an error during the post of new results, the error is logged but overall the job succeeds. 

```
Running with gitlab-runner 16.1.0 (b72e108d)
  on docker-runner 15iA64p4c, system ID: r_FkSFMFLlwSfu
Preparing the "docker" executor
00:03
Using Docker executor with image ls1tum/artemis-notification-plugin:1.1.0 ...

...

$ cp /notification-plugin/artemis-notification-plugin.jar .
$ java -jar artemis-notification-plugin.jar
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
09:05:57.94[8](http://localhost:8081/TESTUPDATE/testupdate-artemis_admin/-/jobs/68#L8) [main] ERROR de.tum.cit.ase.artemis_notification_plugin.NotificationPlugin - Sending test results failed (403) with response: {[0x32]  "type" : "https://www.jhipster.tech/problem/problem-with-message",[0x77]  "title" : "Forbidden",[0x[9](http://localhost:8081/TESTUPDATE/testupdate-artemis_admin/-/jobs/68#L9)0]  "status" : 403,[0xa2]  "detail" : "You are not allowed to access this resource",[0xde]  "path" : "/api/public/programming-exercises/new-result",[0x[11](http://localhost:8081/TESTUPDATE/testupdate-artemis_admin/-/jobs/68#L11)9]  "message" : "error.http.403"[0x[13](http://localhost:8081/TESTUPDATE/testupdate-artemis_admin/-/jobs/68#L13)8]}
org.apache.http.HttpException: Sending test results failed (403) with response: {[0x32]  "type" : "https://www.jhipster.tech/problem/problem-with-message",[0x77]  "title" : "Forbidden",[0x90]  "status" : 403,[0xa2]  "detail" : "You are not allowed to access this resource",[0xde]  "path" : "/api/public/programming-exercises/new-result",[0x119]  "message" : "error.http.403"[0x138]}
	at de.tum.cit.ase.artemis_notification_plugin.NotificationPlugin.postResult(NotificationPlugin.java:88) ~[artemis-notification-plugin.jar:?]
	at de.tum.cit.ase.artemis_notification_plugin.NotificationPlugin.run(NotificationPlugin.java:66) ~[artemis-notification-plugin.jar:?]
	at de.tum.cit.ase.artemis_notification_plugin.CLIPlugin.main(CLIPlugin.java:19) ~[artemis-notification-plugin.jar:?]
Job succeeded
```

This PR changes this behaviour as an exception is thrown which lets the plugin fail.
