### PR TITLE
Bump version of the plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ WORKDIR /notification-plugin
 COPY --from=build /notification-plugin/build/libs/artemis-notification-plugin-*.jar /notification-plugin/artemis-notification-plugin.jar
 
 # In GitLab CI each stage needs a script, which is executed in the container.
-# Therefore, we do not need a CMD or ENTRYPOINT in the Dockerfile, since we execute gradle run directly.
+# Therefore, we do not need a CMD or ENTRYPOINT in the Dockerfile, since we run the jar directly within the continuous integration system.
 # c.f. https://gitlab.com/gitlab-org/gitlab/-/issues/19717

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group "de.tum.cit.ase.artemis_notification_plugin"
-version "0.0.1"
+version "1.2.0"
 description "Notification Plugin for Sending Test Reports to Artemis"
 
 repositories {


### PR DESCRIPTION
In the last release, the jar was not added, as the release defined in grade did not match the one defined in GitHub.
This PR bumps the version of the plugin, so the new release can be made after the merge of #9, #7, and #6.